### PR TITLE
Fixed null check operator issue

### DIFF
--- a/lib/page_view.dart
+++ b/lib/page_view.dart
@@ -128,8 +128,7 @@ class _ConcentricPageViewState extends State<ConcentricPageView> {
               builder: (BuildContext context, child) {
                 // on the first render, the pageController.page is null,
                 // this is a dirty hack
-                if (_pageController?.position?.minScrollExtent == null ||
-                    _pageController?.position?.maxScrollExtent == null) {
+                if (!_pageController.position.hasContentDimensions) {
                   Future.delayed(Duration(microseconds: 1), () {
                     setState(() {});
                   });


### PR DESCRIPTION
Removed checking if `minScrollExtent == null` and `maxScrollExtent == null` in favour of `!_pageController.position.hasContentDimensions`, eliminating the null check issue, making the package compatible with Flutter 2.0.

Thank you for making this package, it's beautiful, and I love using it for onboarding in my apps.

Cheers,
Richard